### PR TITLE
remove URL rewriting in the nginx proxy

### DIFF
--- a/nginxconf/slipstream.conf
+++ b/nginxconf/slipstream.conf
@@ -15,7 +15,11 @@ server {
         proxy_pass http://127.0.0.1:8182;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_redirect http://$host/ https://$host/;
+
+        proxy_redirect off;
+        proxy_buffering off;
+        #proxy_redirect http://$host/ https://$host/;
     }
 }


### PR DESCRIPTION
Removes the URL rewriting in the nginx proxy.  This is no longer needed after the SlipStreamServer has been patched to consistently use the URL scheme passed by the proxy.

(See SlipStream/SlipStreamServer#177 and SlipStream/SlipStreamServer#180)
