### PR TITLE
Nginx tweaks

### DIFF
--- a/nginxconf/src/main/resources/conf/slipstream-extra/compression.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/compression.block
@@ -1,0 +1,15 @@
+# Enable compression & decompression
+
+gzip on;
+gunzip on;
+gzip_types text/plain text/xml text/css text/javascript text/x-component
+           application/json application/javascript application/x-javascript application/xml 
+           application/rss+xml application/atom+xml application/rdf+xml 
+           application/vnd.ms-fontobject application/x-font-ttf
+           application/x-web-app-manifest+json application/xhtml+xml
+           image/svg+xml image/x-icon
+           font/opentype;
+gzip_comp_level 6;
+gzip_proxied any;
+gzip_vary on;
+

--- a/nginxconf/src/main/resources/conf/slipstream-extra/limit-reports.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/limit-reports.block
@@ -1,0 +1,16 @@
+# Limit the number of reports that can be sent simultaneously
+# Return 429 Too Many Requests if the limit is exceeded
+
+# Please add the following lines in http:
+#    map $request_method $reports_limit_key {
+#        default         "";
+#        PUT             "True";
+#    }
+#    limit_conn_zone $reports_limit_key zone=reportslimit:10k;
+
+location ~ ^/reports/ {
+    include conf.d/slipstream-proxy.params;
+    
+    limit_conn reportslimit 10;
+}
+

--- a/nginxconf/src/main/resources/conf/slipstream-extra/limits.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/limits.block
@@ -1,0 +1,22 @@
+# Limit the number of connections per client and per server
+# Limit the request rate per client and per server
+# Return 429 Too Many Requests if the limit is exceeded
+
+# Please add the following lines in http:
+#    limit_conn_zone $binary_remote_addr zone=connperclientlimit:10m;
+#    limit_conn_zone $server_name zone=connperserverlimit:500k;
+#    limit_req_zone $binary_remote_addr zone=rateperclientlimit:10m rate=2r/s;
+#    limit_req_zone $server_name zone=rateperserverlimit:500k rate=50r/s;
+
+limit_conn connperclientlimit 40;
+limit_conn connperserverlimit 1000;
+
+limit_conn_log_level warn;
+limit_conn_status 429;
+
+limit_req zone=rateperclientlimit burst=100 nodelay;
+limit_req zone=rateperserverlimit burst=100 nodelay;
+
+limit_req_log_level warn;
+limit_req_status 429;
+

--- a/nginxconf/src/main/resources/conf/slipstream-extra/long-timeout.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/long-timeout.block
@@ -1,5 +1,6 @@
     # Increase the timeout for resources that may take time to complete
     location ~ ^/run/[^/]+/?$ {
         include conf.d/slipstream-proxy.params;
-        proxy_read_timeout 600;
+        
+        proxy_read_timeout 900;
     }

--- a/nginxconf/src/main/resources/conf/slipstream-extra/nginx-status.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/nginx-status.block
@@ -1,0 +1,14 @@
+# Enable nginx status (eg: to be used with collectd)
+
+# Collectd config example:
+#   LoadPlugin nginx
+#   <Plugin nginx>
+#	   URL "http://localhost/nginx_status"
+#   </Plugin>
+
+location /nginx_status {
+   stub_status on;
+   access_log  off;
+   allow 127.0.0.1;
+   deny all;
+}

--- a/nginxconf/src/main/resources/conf/slipstream-extra/static-content.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/static-content.block
@@ -6,7 +6,6 @@
     # Serve all static contents directly by nginx.
     location ~ ^/(images|external|css|js|font|html|pdf|epub|themes)/ {
         root /opt/slipstream/server/webapps/slipstream.war/static-content;
-        gzip_types *;
         etag on;
         expires 604800;
         if_modified_since before;

--- a/nginxconf/src/main/resources/conf/slipstream-proxy.params
+++ b/nginxconf/src/main/resources/conf/slipstream-proxy.params
@@ -1,6 +1,9 @@
-proxy_pass http://127.0.0.1:8182;
+proxy_pass http://slipstream_servers;
+
+proxy_http_version 1.1;
 
 proxy_set_header Host $host;
+proxy_set_header Connection "";
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginxconf/src/main/resources/conf/slipstream-redirect.conf
+++ b/nginxconf/src/main/resources/conf/slipstream-redirect.conf
@@ -4,5 +4,11 @@
 #
 server {
     listen 80 default;
-    return 301 https://$host$request_uri;
+    
+    location / {
+        return 301 https://$host$request_uri;
+    }
+    
+    # Enable nginx status (eg: to be used with collectd)
+    include conf.d/slipstream-extra/nginx-status.block;
 }

--- a/nginxconf/src/main/resources/conf/slipstream-ssl.conf
+++ b/nginxconf/src/main/resources/conf/slipstream-ssl.conf
@@ -7,13 +7,29 @@
 # Location of the cache on disk. It should exist and be writable by nginx user.
 proxy_cache_path /tmp/slipstream/nginx/cache keys_zone=zone_one:10m;
 
+# For 'slipstream-extra/limit-reports.block'
+map $request_method $reports_limit_key {
+    default         "";
+    PUT             "True";
+}
+limit_conn_zone $reports_limit_key zone=reportslimit:100k;
+
+# For 'slipstream-extra/limits.block'
+limit_conn_zone $binary_remote_addr zone=connperclientlimit:10m;
+limit_conn_zone $server_name zone=connperserverlimit:500k;
+limit_req_zone $binary_remote_addr zone=rateperclientlimit:10m rate=2r/s;
+limit_req_zone $server_name zone=rateperserverlimit:500k rate=50r/s;
+
+upstream slipstream_servers {
+    server 127.0.0.1:8182;
+
+    keepalive 50;
+}
+
 server {
     listen 443 ssl spdy;
 
     charset utf-8;
-    
-    gzip on;
-    gunzip on;
 
     ssl_certificate /etc/nginx/ssl/server.crt;
     ssl_certificate_key /etc/nginx/ssl/server.key;
@@ -26,12 +42,21 @@ server {
         include conf.d/slipstream-proxy.params;
     }
 
+    # Limit the number of connections and the request rate per client and per server
+    include conf.d/slipstream-extra/limits.block;
+
+    # Enable compression & decompression
+    include conf.d/slipstream-extra/compression.block;
+
     # Cache GETs of ss:state of all the runs.
     include conf.d/slipstream-extra/cache-state.block;
 
     # Serve all static content directly by nginx.
     include conf.d/slipstream-extra/static-content.block;
-    
-    # Increase the timeout for resources that may take time to complete
+
+    # Increase the timeout for resources that may take time to complete.
     include conf.d/slipstream-extra/long-timeout.block;
+
+    # Limit the number of reports that can be sent simultaneously.
+    include conf.d/slipstream-extra/limit-reports.block;
 }


### PR DESCRIPTION
- Improved how backend servers are handled.
- Added connections and rates limits (per client and per server).
- Limit the number of reports that can be sent simultaneously to 10.
- Compress only meaningful types and proxied requests.
- Increase the gateway timeout for DELETE on Run to 15 minutes.
- Enable nginx_status for localhost (to be used for example with collectd).
- Enable keep-alive connections with the backend server and with clients.