### PR TITLE
Allow to set SlipStream (via nginx) into maintenance mode and define custom error pages.

### DIFF
--- a/nginxconf/src/main/resources/conf/slipstream-extra/http_accept-type.map
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/http_accept-type.map
@@ -1,0 +1,19 @@
+# Mapping between $http_accept and the resulting $type.
+# This mapping is used by error-pages.block to set the file extension of error pages.
+
+default                       "txt";    
+
+"~*text/html.*"               "html";
+"~*text/plain.*"              "txt";
+"~*text/xml.*"                "xml";
+"~*application/xml.*"         "xml";
+"~*application/json.*"        "json";
+"~*application/xhtml+xml.*"   "html";
+
+"~*.*text/html.*"             "html";
+"~*.*text/plain.*"            "txt";
+"~*.*text/xml.*"              "xml";
+"~*.*application/xml.*"       "xml";
+"~*.*application/jso.*"       "json";
+"~*.*application/xhtml+xml.*" "html";
+

--- a/nginxconf/src/main/resources/conf/slipstream-extra/maintenance-mode-error-pages.block
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/maintenance-mode-error-pages.block
@@ -1,0 +1,32 @@
+# Define custom error pages and allow to set the server in maintenance mode.
+
+# Please add the following lines in http:
+#
+#    map $http_accept $type {
+#        include      conf.d/slipstream-extra/http_accept-type.map;
+#    }
+#
+#    map $remote_addr $maintenance {
+#        include      conf.d/slipstream-extra/maintenance.map;
+#    }
+
+error_page 404 /errors/404.$type;  # Not Found
+error_page 429 /errors/429.$type;  # Too Many Requests
+error_page 502 /errors/502.$type;  # Bad Gateway
+error_page 503 @maintenance;       # Service Unavailable
+error_page 504 /errors/504.$type;  # Gateway Time-out
+
+location /errors/ {
+    root /opt/slipstream/server/webapps/slipstream.war/static-content;
+    internal;
+}
+
+location @maintenance {
+    root /opt/slipstream/server/webapps/slipstream.war/static-content;
+    rewrite ^(.*)$ /errors/503.$type break;
+}
+
+if ($maintenance) {
+    return 503;
+}
+

--- a/nginxconf/src/main/resources/conf/slipstream-extra/maintenance.map
+++ b/nginxconf/src/main/resources/conf/slipstream-extra/maintenance.map
@@ -1,0 +1,18 @@
+# This file define which IPs will receive an error page which explain that the application is in maintenance.
+# 0 - Maintenance disabled
+# 1 - Maintenance enabled
+# One IP per line
+
+default  0;
+
+# Localhost
+"~^127\.[0-9]+\.[0-9]+\.[0-9]+$" 0;
+
+# Autoconfig IPs
+# "~^169\.254\.[0-9]+\.[0-9]+$"  0;
+
+# Pivate subnets
+# "~^10\.[0-9]+\.[0-9]+\.[0-9]+$"  0;
+# "~^192\.168\.[0-9]+\.[0-9]+$"    0;
+# "~^172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+$"  0;
+

--- a/nginxconf/src/main/resources/conf/slipstream-ssl.conf
+++ b/nginxconf/src/main/resources/conf/slipstream-ssl.conf
@@ -34,6 +34,14 @@ limit_conn_zone $server_name zone=connperserverlimit:500k;
 limit_req_zone $binary_remote_addr zone=rateperclientlimit:10m rate=5r/s;
 limit_req_zone $server_name zone=rateperserverlimit:500k rate=50r/s;
 
+map $http_accept $type {
+    include      conf.d/slipstream-extra/http_accept-type.map;
+}
+
+map $remote_addr $maintenance {
+    include      conf.d/slipstream-extra/maintenance.map;
+}
+
 upstream slipstream_servers {
     server 127.0.0.1:8182;
 
@@ -73,4 +81,8 @@ server {
 
     # Limit the number of reports that can be sent simultaneously.
     include conf.d/slipstream-extra/limit-reports.block;
+
+    # Serve custom error pages and allow to set the server in maintenance mode.
+    include conf.d/slipstream-extra/maintenance-mode-error-pages.block;
 }
+


### PR DESCRIPTION
Fix #13.
Require slipstream/SlipStreamUI#271 to be merged.
Related to slipstream/SlipStreamServer#310.