### PR TITLE
Added backports.ssl-match-hostname package required for libcloud 

### DIFF
--- a/libcloud/rpm/pom.xml
+++ b/libcloud/rpm/pom.xml
@@ -59,6 +59,7 @@
                 <argument>-C</argument>
                 <argument>${project.build.directory}/dependency</argument>
                 <argument>libcloud</argument>
+                <argument>backports</argument>
               </arguments>
             </configuration>
           </execution>

--- a/libcloud/zip/pom.xml
+++ b/libcloud/zip/pom.xml
@@ -12,6 +12,10 @@
     <version>2.16-SNAPSHOT</version>
   </parent>
 
+  <properties>
+      <ssl-match-hostname.version>3.2a3</ssl-match-hostname.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.libcloud</groupId>
@@ -39,7 +43,6 @@
         </executions>
       </plugin>
 
-<!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -55,12 +58,12 @@
               <executable>mkdir</executable>
               <arguments>
                 <argument>-p</argument>
-                <argument>${project.build.directory}</argument>
+                <argument>${project.build.directory}/dependency</argument>
               </arguments>
             </configuration>
           </execution>
           <execution>
-            <id>get-libcloud</id>
+            <id>get-backports</id>
             <phase>process-resources</phase>
             <goals>
               <goal>exec</goal>
@@ -70,33 +73,29 @@
               <arguments>
                 <argument>-sSfL</argument>
                 <argument>-o</argument>
-                <argument>${project.build.directory}/apache-libcloud-${libcloud.version}.tar.bz2</argument>
-                <argument>http://pypi.python.org/packages/source/a/apache-libcloud/apache-libcloud-${libcloud.version}.tar.bz2</argument>
+                <argument>${project.build.directory}/dependency/backports.ssl_match_hostname-${ssl-match-hostname.version}.tar.gz</argument>
+                <argument>https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-${ssl-match-hostname.version}.tar.gz</argument>
               </arguments>
             </configuration>
           </execution>
           <execution>
-            <id>unpack-libcloud</id>
+            <id>unpack-backports</id>
             <phase>process-resources</phase>
             <goals>
               <goal>exec</goal>
             </goals>
             <configuration>
-              <workingDirectory>${project.build.directory}</workingDirectory>
+              <workingDirectory>${project.build.directory}/dependency</workingDirectory>
               <executable>tar</executable>
               <arguments>
-                <argument>XXXXstrip-components</argument>
-                <argument>1</argument>
-                <argument>-jxvf</argument>
-                <argument>apache-libcloud-${libcloud.version}.tar.bz2</argument>
-                <argument>apache-libcloud-${libcloud.version}/libcloud</argument>
+                <argument>-zxvf</argument>
+                <argument>backports.ssl_match_hostname-${ssl-match-hostname.version}.tar.gz</argument>
               </arguments>
             </configuration>
           </execution>
 
         </executions>
       </plugin>
--->
 
 <!--
       <plugin>

--- a/libcloud/zip/src/main/assembly/bundle.xml
+++ b/libcloud/zip/src/main/assembly/bundle.xml
@@ -21,7 +21,7 @@
       </excludes>
     </fileSet>
     <fileSet>
-        <directory>${project.build.directory}/dependency/backports.ssl_match_hostname-${ssl-match-hostname.version}/src/</directory>
+        <directory>${project.build.directory}/dependency/backports.ssl_match_hostname-${ssl-match-hostname.version}/src/backports</directory>
       <directoryMode>755</directoryMode>
       <fileMode>644</fileMode>
       <outputDirectory>backports</outputDirectory>

--- a/libcloud/zip/src/main/assembly/bundle.xml
+++ b/libcloud/zip/src/main/assembly/bundle.xml
@@ -2,12 +2,12 @@
   <id>bundle</id>
 
   <includeBaseDirectory>false</includeBaseDirectory>
-  
+
   <formats>
     <format>zip</format>
     <format>tar.gz</format>
   </formats>
-  
+
   <fileSets>
 
     <fileSet>
@@ -20,7 +20,17 @@
         <exclude>**/*.pyc</exclude>
       </excludes>
     </fileSet>
-    
+    <fileSet>
+        <directory>${project.build.directory}/dependency/backports.ssl_match_hostname-${ssl-match-hostname.version}/src/</directory>
+      <directoryMode>755</directoryMode>
+      <fileMode>644</fileMode>
+      <outputDirectory>backports</outputDirectory>
+      <excludes>
+        <exclude>**/*.pyc</exclude>
+        <exclude>**/*.pyo</exclude>
+      </excludes>
+    </fileSet>
+
   </fileSets>
-  
+
 </assembly>


### PR DESCRIPTION
Connected to #17 

This is a bug that slipped to v2.15 candidate and a result of the migration to `libcloud` 0.18.0.  
The testing and the demo were done using Python "live unit tests" on the local machine where `libcloud` was installed with `backports.ssl-match-hostname` as dependency. 

Now the fix was validated on a live instance with nuv.la prod db.