### PR TITLE
Disable halt-on-error behaviour before running S3-util

### DIFF
--- a/backup/src/slipstream-backup.sh
+++ b/backup/src/slipstream-backup.sh
@@ -33,12 +33,13 @@ gpg-zip --encrypt --gpg-args "--yes --trust-model always -r SixSq" \
 
 BACKUP=$AMAZON_BUCKET/$BUNDLE_NAME
 
+set +e
 output=$(/opt/slipstream/backup/s3curl.pl --id sixsq --put $BUNDLE -- -f $BACKUP 2>&1)
-if [ "$?" -eq "0" ]; then
+rc=$?
+if [ "$rc" -eq "0" ]; then
     echo "SlipStream Backup Successful. $BACKUP"
     touch ${BACKUP_TIMESTAMP}
-    exit 0
 else
     echo "FAILURE $BACKUP: $output"
-    exit 1
 fi
+exit $rc


### PR DESCRIPTION
Needed to be able to print the error message from the S3 utility.