### PR TITLE
migration of hsqldb and nginx configuration to centos 7

### DIFF
--- a/hsqldb/rpm/pom.xml
+++ b/hsqldb/rpm/pom.xml
@@ -143,7 +143,7 @@
 						</mapping>
 
 						<mapping>
-							<directory>/etc/sysconfig</directory>
+							<directory>/etc</directory>
 							<filemode>664</filemode>
 							<username>slipstream</username>
 							<groupname>slipstream</groupname>

--- a/hsqldb/rpm/pom.xml
+++ b/hsqldb/rpm/pom.xml
@@ -53,29 +53,6 @@
 
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>update-initd</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-						<configuration>
-							<executable>sed</executable>
-							<arguments>
-								<argument>-i</argument>
-								<argument>-e</argument>
-								<argument>s/^MAX_START_SECS=.*$/MAX_START_SECS=15/;s/#chkconfig:.*/# chkconfig: 36 70 35/</argument>
-								<argument>${project.build.directory}/hsqldb/sample/hsqldb.init</argument>
-							</arguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>rpm-maven-plugin</artifactId>
 				<extensions>true</extensions>
 				<configuration>
@@ -132,15 +109,18 @@
 								</source>
 							</sources>
 						</mapping>
-                        <mapping>
-                            <directory>/etc/rc.d/init.d</directory>
-                            <sources>
-                                <softlinkSource>
-                                    <destination>hsqldb</destination>
-                                    <location>/opt/hsqldb/sample/hsqldb.init</location>
-                                </softlinkSource>
-                            </sources>
-                        </mapping>
+						<mapping>
+							<directory>/usr/lib/systemd/system</directory>
+							<filemode>644</filemode>
+							<username>root</username>
+							<groupname>root</groupname>
+							<directoryIncluded>false</directoryIncluded>
+							<sources>
+								<source>
+									<location>src/etc/hsqldb.service</location>
+								</source>
+							</sources>
+						</mapping>
 
 						<mapping>
 							<directory>/opt/hsqldb/data</directory>
@@ -163,7 +143,7 @@
 						</mapping>
 
 						<mapping>
-							<directory>/etc</directory>
+							<directory>/etc/sysconfig</directory>
 							<filemode>664</filemode>
 							<username>slipstream</username>
 							<groupname>slipstream</groupname>
@@ -175,26 +155,12 @@
 							</sources>
 						</mapping>
 
-						<mapping>
-                            <directory>/usr/sbin</directory>
-							<filemode>755</filemode>
-							<username>root</username>
-							<groupname>root</groupname>
-							<directoryIncluded>false</directoryIncluded>
-							<sources>
-								<source>
-                                    <location>src/sbin/ss-db-shutdown</location>
-								</source>
-							</sources>
-						</mapping>
-
 					</mappings>
 
 					<postinstallScriptlet>
 						<script>
-/sbin/chkconfig --add hsqldb
-/bin/chown -R slipstream: /opt/slipstream/SlipStreamDB
-            </script>
+/usr/bin/systemctl enable hsqldb.service
+						</script>
 					</postinstallScriptlet>
 
 				</configuration>

--- a/hsqldb/rpm/src/etc/hsqldb.service
+++ b/hsqldb/rpm/src/etc/hsqldb.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Hsqldb Service
+After=syslog.target network.target
+Before=ssclj.service slipstream.service
+
+[Service]
+RemainAfterExit=yes
+Type=oneshot
+ExecStart=/opt/hsqldb/sample/hsqldb.init start
+ExecStop=/opt/hsqldb/sample/hsqldb.init stop
+ExecReload=/opt/hsqldb/sample/hsqldb.init restart
+
+[Install]
+WantedBy=multi-user.target
+

--- a/hsqldb/rpm/src/sbin/ss-db-shutdown
+++ b/hsqldb/rpm/src/sbin/ss-db-shutdown
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-for db in slipstream ssclj; do
-    java -jar /opt/hsqldb/lib/sqltool.jar \
-       --inlineRc=url=jdbc:hsqldb:hsql://localhost:9001/${db},user=sa,password= \
-       --sql 'SHUTDOWN;' || true
-done

--- a/nginxconf/pom.xml
+++ b/nginxconf/pom.xml
@@ -52,14 +52,13 @@ NGINX_DEFAULT=/etc/nginx/conf.d/default.conf
 
 /opt/slipstream/server/sbin/generate-nginx-certificate.sh || true
 
-/sbin/service nginx reload || /sbin/service nginx start
-/sbin/chkconfig --add nginx
+/usr/bin/systemctl enable nginx
 </script>
           </postinstallScriptlet>
 
           <postremoveScriptlet>
             <script>
-/sbin/service nginx reload || true
+/usr/bin/systemctl reload nginx || true
 </script>
           </postremoveScriptlet>
 
@@ -93,10 +92,10 @@ NGINX_DEFAULT=/etc/nginx/conf.d/default.conf
 	    </mapping>
 	    
 	    <mapping>
-	      <directory>/tmp/slipstream/nginx/cache</directory>
-	      <filemode>664</filemode>
-	      <username>slipstream</username>
-	      <groupname>slipstream</groupname>
+	      <directory>/var/run/slipstream/nginx/cache</directory>
+	      <filemode>744</filemode>
+	      <username>nginx</username>
+	      <groupname>nginx</groupname>
 	    </mapping>
 
 	  </mappings>

--- a/nginxconf/src/main/resources/conf/slipstream-ssl.conf
+++ b/nginxconf/src/main/resources/conf/slipstream-ssl.conf
@@ -5,7 +5,7 @@
 #
 
 # Location of the cache on disk. It should exist and be writable by nginx user.
-proxy_cache_path /tmp/slipstream/nginx/cache keys_zone=zone_one:10m;
+proxy_cache_path /var/run/slipstream/nginx/cache keys_zone=zone_one:10m;
 
 # For 'slipstream-extra/limit-reports.block'
 map $request_method $reports_limit_key {


### PR DESCRIPTION
- hsqldb: from `init.d` to `systemd`
- nginx: don't start `nginx` from configuration PRM; move SS cache to `/var/run/slipstream/nginx/cache`

Connected to https://github.com/slipstream/SlipStreamServerDeps/issues/26 and https://github.com/slipstream/SlipStreamServerDeps/issues/27 (https://github.com/SixSq/tasklist/issues/618)