### PR TITLE
move nginx cache to /var/local/slipstream

### DIFF
--- a/nginxconf/pom.xml
+++ b/nginxconf/pom.xml
@@ -88,7 +88,7 @@ NGINX_DEFAULT=/etc/nginx/conf.d/default.conf
 	    </mapping>
 	    
 	    <mapping>
-	      <directory>/var/run/slipstream/nginx/cache</directory>
+	      <directory>/var/local/slipstream/nginx/cache</directory>
 	      <filemode>744</filemode>
 	      <username>nginx</username>
 	      <groupname>nginx</groupname>

--- a/nginxconf/src/main/resources/conf/slipstream-ssl.conf
+++ b/nginxconf/src/main/resources/conf/slipstream-ssl.conf
@@ -5,7 +5,7 @@
 #
 
 # Location of the cache on disk. It should exist and be writable by nginx user.
-proxy_cache_path /var/run/slipstream/nginx/cache keys_zone=zone_one:10m;
+proxy_cache_path /var/local/slipstream/nginx/cache keys_zone=zone_one:10m;
 
 # For 'slipstream-extra/limit-reports.block'
 map $request_method $reports_limit_key {


### PR DESCRIPTION
cache should not be in /var/run/slipstream because after a reboot of system, all folders and files in /var/run are removed