### PR TITLE
remove reference to deleted config

### DIFF
--- a/nginxconf/src/main/resources/conf/slipstream.params
+++ b/nginxconf/src/main/resources/conf/slipstream.params
@@ -32,9 +32,6 @@ include conf.d/slipstream-extra/cache.block;
 # Serve all static content directly by nginx.
 include conf.d/slipstream-extra/static-content.block;
 
-# Serve alternate web browser user interface as static content.
-include conf.d/slipstream-extra/authn.block;
-
 # Increase the timeout for resources that may take time to complete.
 include conf.d/slipstream-extra/long-timeout.block;
 


### PR DESCRIPTION
Remove reference to deleted configuration file, so that nginx starts correctly.